### PR TITLE
fix: 日付バインディングが locale で曜日/月名を翻訳する問題を修正

### DIFF
--- a/src/Bindings/DateFormatter.php
+++ b/src/Bindings/DateFormatter.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Locale-independent date formatter for binding providers.
+ *
+ * @package Feedwright
+ */
+
+declare(strict_types=1);
+
+namespace Feedwright\Bindings;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Format Unix timestamps with the site timezone but English day/month names.
+ *
+ * `wp_date()` (and helpers like `get_the_date()` that wrap it) translate
+ * `D` / `M` / `l` / `F` format characters to the site locale. That breaks
+ * format strings such as `r` (RFC 2822) and `D, d M Y H:i:s O`, which the
+ * RFC 2822 / RFC 3339 specs require to be in English regardless of locale.
+ *
+ * This helper uses `DateTimeImmutable::format()` instead, which always
+ * produces English names — exactly matching PHP's bare `date()` behavior.
+ * Numeric formats (`Y`, `m`, `d`, etc.) are unaffected either way.
+ */
+final class DateFormatter {
+
+	/**
+	 * Format a Unix timestamp as a string using the given PHP date format.
+	 *
+	 * @param int                       $timestamp Unix timestamp (UTC).
+	 * @param string                    $format    PHP date format string.
+	 * @param \DateTimeZone|string|null $timezone  Output timezone. Defaults to site timezone.
+	 */
+	public static function format( int $timestamp, string $format, $timezone = null ): string {
+		if ( null === $timezone ) {
+			$timezone = wp_timezone();
+		} elseif ( is_string( $timezone ) ) {
+			$timezone = new \DateTimeZone( $timezone );
+		}
+		$dt = ( new \DateTimeImmutable( '@' . $timestamp ) )->setTimezone( $timezone );
+		return $dt->format( $format );
+	}
+}

--- a/src/Bindings/Providers/FeedProvider.php
+++ b/src/Bindings/Providers/FeedProvider.php
@@ -11,6 +11,7 @@ namespace Feedwright\Bindings\Providers;
 
 use Feedwright\Renderer\Context;
 use Feedwright\Routing\FeedEndpoint;
+use Feedwright\Bindings\DateFormatter;
 use Feedwright\Bindings\ProviderInterface;
 
 defined( 'ABSPATH' ) || exit;
@@ -86,7 +87,7 @@ final class FeedProvider implements ProviderInterface {
 	 */
 	private function format_date( int $timestamp, string $modifier ): string {
 		$format = '' === $modifier ? 'r' : $modifier;
-		return (string) wp_date( $format, $timestamp );
+		return DateFormatter::format( $timestamp, $format );
 	}
 
 	/**

--- a/src/Bindings/Providers/NowProvider.php
+++ b/src/Bindings/Providers/NowProvider.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Feedwright\Bindings\Providers;
 
 use Feedwright\Renderer\Context;
+use Feedwright\Bindings\DateFormatter;
 use Feedwright\Bindings\ProviderInterface;
 
 defined( 'ABSPATH' ) || exit;
@@ -41,7 +42,7 @@ final class NowProvider implements ProviderInterface {
 			return null;
 		}
 		$format = '' === $modifier ? 'c' : $modifier;
-		return (string) wp_date( $format );
+		return DateFormatter::format( time(), $format );
 	}
 
 	/**

--- a/src/Bindings/Providers/PostProvider.php
+++ b/src/Bindings/Providers/PostProvider.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Feedwright\Bindings\Providers;
 
 use Feedwright\Renderer\Context;
+use Feedwright\Bindings\DateFormatter;
 use Feedwright\Bindings\ProviderInterface;
 
 defined( 'ABSPATH' ) || exit;
@@ -50,9 +51,15 @@ final class PostProvider implements ProviderInterface {
 			case 'post_excerpt':
 				return (string) get_the_excerpt( $post );
 			case 'post_date':
-				return (string) get_the_date( '' === $modifier ? 'c' : $modifier, $post );
+				return DateFormatter::format(
+					(int) get_post_time( 'U', true, $post ),
+					'' === $modifier ? 'c' : $modifier
+				);
 			case 'post_modified':
-				return (string) get_the_modified_date( '' === $modifier ? 'c' : $modifier, $post );
+				return DateFormatter::format(
+					(int) get_post_modified_time( 'U', true, $post ),
+					'' === $modifier ? 'c' : $modifier
+				);
 			case 'post_status':
 				return (string) get_post_status( $post );
 			case 'post_name':

--- a/src/Bindings/Providers/PostRawProvider.php
+++ b/src/Bindings/Providers/PostRawProvider.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Feedwright\Bindings\Providers;
 
 use Feedwright\Renderer\Context;
+use Feedwright\Bindings\DateFormatter;
 use Feedwright\Bindings\ProviderInterface;
 
 defined( 'ABSPATH' ) || exit;
@@ -79,7 +80,7 @@ final class PostRawProvider implements ProviderInterface {
 			if ( false === $date_time ) {
 				return $raw;
 			}
-			return (string) wp_date( $modifier, $date_time->getTimestamp(), $timezone );
+			return DateFormatter::format( $date_time->getTimestamp(), $modifier, $timezone );
 		}
 
 		return null;


### PR DESCRIPTION
Closes #1

## Summary
\`wp_date()\` / \`get_the_date()\` が D/M/l/F format をサイト locale に翻訳するため、\`{{now:r}}\` / \`{{feed.last_build_date:r}}\` などの RFC 2822 出力が ja 環境で「月, 27 4月 2026 ...」となっていた。

\`DateTimeImmutable::format()\` を使う \`Feedwright\\Bindings\\DateFormatter\` を追加し、4 つの provider (Feed / Now / Post / PostRaw) の \`wp_date\` を差し替え。

## Verification (locale=ja)
- \`{{now:r}}\` → \`Mon, 27 Apr 2026 21:08:20 +0900\` ✓
- \`{{feed.last_build_date:r}}\` → \`Mon, 27 Apr 2026 21:08:20 +0900\` ✓

## Test plan
- [x] phpcs / phpunit unit / integration
- [x] 実機 wp eval で英語出力を確認