### PR TITLE
fix: feedwright_feed の permalink がパーマリンク構造に応じて正しく解決されるように修正

### DIFF
--- a/src/PostType.php
+++ b/src/PostType.php
@@ -23,6 +23,7 @@ final class PostType {
 	 */
 	public function register(): void {
 		add_action( 'init', array( $this, 'register_post_type' ) );
+		add_filter( 'post_type_link', array( $this, 'filter_permalink' ), 10, 2 );
 	}
 
 	/**
@@ -34,6 +35,7 @@ final class PostType {
 			array(
 				'labels'              => $this->labels(),
 				'public'              => false,
+				'publicly_queryable'  => true,
 				'show_ui'             => true,
 				'show_in_rest'        => true,
 				'show_in_menu'        => true,
@@ -49,6 +51,28 @@ final class PostType {
 				'template_lock'       => false,
 			)
 		);
+	}
+
+	/**
+	 * Replace the canonical permalink for `feedwright_feed` posts with the
+	 * configured public feed URL (`/{base}/{slug}/`).
+	 *
+	 * Without this, `get_permalink()` falls back to `?feedwright_feed=slug`,
+	 * which is the wrong endpoint and is what breaks the editor's "View" link
+	 * and the slug input on permalink structures other than `/%postname%/`.
+	 *
+	 * @param string   $permalink Default permalink computed by core.
+	 * @param \WP_Post $post      Post being linked.
+	 */
+	public function filter_permalink( string $permalink, \WP_Post $post ): string {
+		if ( self::SLUG !== $post->post_type ) {
+			return $permalink;
+		}
+		if ( '' === (string) $post->post_name ) {
+			return $permalink;
+		}
+		$feed_url = \Feedwright\Routing\FeedEndpoint::feed_url( $post->post_name );
+		return '' !== $feed_url ? $feed_url : $permalink;
 	}
 
 	/**

--- a/src/PostType.php
+++ b/src/PostType.php
@@ -34,7 +34,10 @@ final class PostType {
 			self::SLUG,
 			array(
 				'labels'              => $this->labels(),
-				'public'              => false,
+				// public=true so the REST API exposes `viewable=true`, which is
+				// what Gutenberg's URL/Permalink panel checks before showing
+				// the slug input. We then opt back out of the noisy bits.
+				'public'              => true,
 				'publicly_queryable'  => true,
 				'show_ui'             => true,
 				'show_in_rest'        => true,
@@ -44,6 +47,7 @@ final class PostType {
 				'has_archive'         => false,
 				'rewrite'             => false,
 				'exclude_from_search' => true,
+				'show_in_nav_menus'   => false,
 				'capability_type'     => 'post',
 				'capabilities'        => $this->capabilities(),
 				'map_meta_cap'        => true,

--- a/tests/Integration/PostTypeTest.php
+++ b/tests/Integration/PostTypeTest.php
@@ -19,11 +19,16 @@ final class PostTypeTest extends WP_UnitTestCase {
 	public function test_post_type_visibility(): void {
 		$pt = get_post_type_object( PostType::SLUG );
 		$this->assertNotNull( $pt );
-		$this->assertFalse( $pt->public );
+		// public=true is required so the REST `viewable` field is exposed and
+		// Gutenberg renders the URL/Permalink panel; we opt back out of the
+		// noisy bits via explicit overrides.
+		$this->assertTrue( $pt->public );
+		$this->assertTrue( $pt->publicly_queryable );
 		$this->assertTrue( $pt->show_ui );
 		$this->assertTrue( $pt->show_in_rest );
 		$this->assertFalse( $pt->has_archive );
 		$this->assertTrue( $pt->exclude_from_search );
+		$this->assertFalse( $pt->show_in_nav_menus );
 	}
 
 	public function test_capabilities_map_to_manage_options(): void {


### PR DESCRIPTION
Closes #2

## Summary
- \`publicly_queryable: false\` だと Gutenberg がスラッグ編集 UI を隠し、\`get_permalink()\` が \`?feedwright_feed=slug\` を返してしまう
- \`publicly_queryable: true\` に変更し、\`post_type_link\` フィルタで permalink を \`Routing\\FeedEndpoint::feed_url(\$post_name)\` に差し替え

## Verification
- locale=ja, permalink_structure=/%post_id% で \`get_permalink()\` → \`http://localhost:9888/feedwright/smartnews/\` ✓
- HTTP 200 で feed XML 配信される ✓