### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/feedwright.php
+++ b/feedwright.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Feedwright
  * Plugin URI:        https://github.com/mt8/feedwright
  * Description:       Edit custom RSS / Atom / XML feeds visually in the WordPress block editor.
- * Version:           0.1.0
+ * Version:           0.1.1
  * Requires at least: 6.5
  * Requires PHP:      8.3
  * Author:            mt8
@@ -18,7 +18,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'FEEDWRIGHT_VERSION', '0.1.0' );
+define( 'FEEDWRIGHT_VERSION', '0.1.1' );
 define( 'FEEDWRIGHT_PLUGIN_FILE', __FILE__ );
 define( 'FEEDWRIGHT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'FEEDWRIGHT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "feedwright",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Edit custom RSS / Atom / XML feeds visually in the WordPress block editor.",
     "author": "mt8",
     "license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: rss, feed, atom, mrss, xml
 Requires at least: 6.5
 Tested up to: 6.9
 Requires PHP: 8.3
-Stable tag: 0.1.0
+Stable tag: 0.1.1
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -35,6 +35,10 @@ The default URL pattern is `/feedwright/{slug}/`. You can change the prefix in F
 Yes. Declare the namespace prefix and URI on the `<rss>` block, then use prefixed tag names (e.g. `media:thumbnail`) on element blocks and attributes.
 
 == Changelog ==
+
+= 0.1.1 =
+* Fix: date bindings (`{{now:r}}`, `{{feed.last_build_date:r}}`, etc.) now always emit RFC 2822 / RFC 3339 with English day and month names regardless of site locale.
+* Fix: `feedwright_feed` permalinks now resolve correctly under all permalink structures (including `/%post_id%`); the Gutenberg URL / slug panel is now visible.
 
 = 0.1.0 =
 * Initial development release.

--- a/tests/Unit/PluginHeaderTest.php
+++ b/tests/Unit/PluginHeaderTest.php
@@ -36,7 +36,7 @@ final class PluginHeaderTest extends TestCase {
 	public function test_plugin_header_metadata(): void {
 		$header = $this->read_header();
 		$this->assertSame( 'Feedwright', $header['Plugin Name'] ?? '' );
-		$this->assertSame( '0.1.0', $header['Version'] ?? '' );
+		$this->assertSame( '0.1.1', $header['Version'] ?? '' );
 		$this->assertSame( '8.3', $header['Requires PHP'] ?? '' );
 		$this->assertSame( '6.5', $header['Requires at least'] ?? '' );
 		$this->assertSame( 'feedwright', $header['Text Domain'] ?? '' );


### PR DESCRIPTION
Closes #5

含まれる修正:
- #1 日付バインディングの locale 翻訳問題
- #2 permalink / Gutenberg URL パネル問題