### PR TITLE
fix: item-template は item-query ごとに 1 個（投稿全体での singleton ではない）

### DIFF
--- a/blocks/item/block.json
+++ b/blocks/item/block.json
@@ -13,7 +13,6 @@
 	"supports": {
 		"html": false,
 		"reusable": false,
-		"multiple": false,
 		"inserter": false
 	},
 	"attributes": {


### PR DESCRIPTION
Closes #7

`item/block.json` から `multiple: false` を削除。`item-query` 側の templateLock + template が各 query 内で item を 1 個に固定するので、「投稿全体では何個でも、各 item-query 内では 1 個」という期待通りに動作する。