### PR TITLE
feat: add `first` / `default` processors and `post_term_meta` binding for aggregator category mapping (#13)

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -114,6 +114,7 @@ feedwright/
 │   │       ├── PostRawProvider.php
 │   │       ├── PostMetaProvider.php
 │   │       ├── PostTermProvider.php
+│   │       ├── PostTermMetaProvider.php
 │   │       └── AuthorProvider.php
 │   ├── Query/
 │   │   └── ArgsBuilder.php
@@ -1393,6 +1394,24 @@ Examples:
 - `{{post_term.category::|}}` → `"News|Tech"`
 - `{{post_term.post_tag:slug::, }}` → `"japan, ai"`
 
+#### `post_term_meta.*` — term meta of the first matching term (only inside item context)
+
+Path format: `{taxonomy}.{meta_key}`. Returns `get_term_meta()` (single value) of the first term `get_the_terms()` returns for the post in `{taxonomy}`. Powers the aggregator category-mapping pattern: each WP term carries an aggregator-side ID (e.g. mediba category ID, SmartNews channel ID) as term meta, and the binding surfaces it without per-feed configuration.
+
+| Binding | Value |
+|---|---|
+| `post_term_meta.{taxonomy}.{meta_key}` | first term's `get_term_meta(... , true)` value |
+
+Examples:
+- `{{post_term_meta.category._mediba_category_id}}` → `"91"` if the first category has that meta set, else `""`
+- `{{post_term_meta.category._mediba_category_id|default:99}}` → `"99"` when meta is unset
+- `{{post_term.category|first|map:お役立ち=91,芸能=92|default:99}}` — alternative inline pattern when the mapping is small enough to hand-author
+
+Returns empty string when:
+- the post has no terms in the taxonomy
+- the meta key is unset on the first term
+- the meta value is an array (only scalar meta is supported)
+
 #### `author.*` — post author (only inside item context)
 
 Resolves through `get_the_author_meta()` using `$post->post_author` as the ID.
@@ -1481,6 +1500,8 @@ You can append `|name:arg` to the end of a binding to apply transforms to the re
 | `allow_tags` | comma-separated tag names | Allow only listed tags via `wp_kses`, no attributes. Empty argument strips all tags |
 | `strip_tags` | (ignored) | Strip all tags via `wp_strip_all_tags` |
 | `map` | `key=val,*=fallback` | If the input matches `key`, return that line's `val`. `*` is the fallback if no key matches. If neither matches nor `*` exists, returns empty string. The first `=` separates key and val, so `=` may appear in val. Useful for conditionals such as mapping `post_status` to a numeric `<media:status>` flag (publish=1 / removed=0): `{{post_raw.post_status\|map:publish=1,*=0}}` |
+| `first` | separator (default `, `) | Returns the first segment of a separator-joined string. Pairs naturally with `post_term.{taxonomy}` (which joins multi-term posts with `", "`) before piping into `map`. Example: `{{post_term.category\|first\|map:Tech=10,News=20}}`. The separator argument cannot contain `\|` (pipe-syntax conflict) or `}`; to split on `\|`, change the upstream binding to emit a different separator via its modifier first |
+| `default` | replacement value | Returns the literal argument when the input is the empty string; otherwise passes the input through unchanged. Differs from `map`'s `*` in that it triggers only on empty input — `"0"` and other falsy-looking strings pass through. Idiomatic with `post_term_meta`: `{{post_term_meta.category._mediba_category_id\|default:99}}` |
 
 Unknown processor names log a warning and pass the input through unchanged.
 
@@ -1508,6 +1529,7 @@ $providers = apply_filters( 'feedwright/binding_providers', [
     new Providers\PostRawProvider(),
     new Providers\PostMetaProvider(),
     new Providers\PostTermProvider(),
+    new Providers\PostTermMetaProvider(),
     new Providers\AuthorProvider(),
 ] );
 ```

--- a/src/Bindings/Providers/PostTermMetaProvider.php
+++ b/src/Bindings/Providers/PostTermMetaProvider.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Binding provider for `post_term_meta.{taxonomy}.{meta_key}` — term meta of
+ * the current post's first term in the given taxonomy.
+ *
+ * @package Feedwright
+ */
+
+declare(strict_types=1);
+
+namespace Feedwright\Bindings\Providers;
+
+use Feedwright\Renderer\Context;
+use Feedwright\Bindings\ProviderInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Spec §14.4 `post_term_meta.*`. Powers the aggregator category-mapping
+ * pattern (e.g. mediba `<category>` requires a CP-assigned numeric ID).
+ *
+ * Editorial teams set the ID once per WP term as term meta; this provider
+ * surfaces it without further per-feed configuration.
+ */
+final class PostTermMetaProvider implements ProviderInterface {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function namespace_name(): string {
+		return 'post_term_meta';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * Path format: `{taxonomy}.{meta_key}`. The meta key may itself contain
+	 * dots; only the first segment is treated as the taxonomy.
+	 *
+	 * @param string  $path     Binding path of the form `taxonomy.meta_key`.
+	 * @param string  $modifier Unused.
+	 * @param Context $ctx      Render context.
+	 */
+	public function resolve( string $path, string $modifier, Context $ctx ): ?string {
+		unset( $modifier );
+
+		$post = $ctx->current_post();
+		if ( ! $post instanceof \WP_Post ) {
+			return null;
+		}
+
+		$dot = strpos( $path, '.' );
+		if ( false === $dot ) {
+			return null;
+		}
+		$taxonomy = substr( $path, 0, $dot );
+		$meta_key = substr( $path, $dot + 1 );
+		if ( '' === $taxonomy || '' === $meta_key ) {
+			return null;
+		}
+
+		$terms = get_the_terms( $post, $taxonomy );
+		if ( is_wp_error( $terms ) || ! is_array( $terms ) || empty( $terms ) ) {
+			return '';
+		}
+
+		// Use the first term as returned by core (taxonomy ordering rules apply).
+		$first = null;
+		foreach ( $terms as $term ) {
+			if ( $term instanceof \WP_Term ) {
+				$first = $term;
+				break;
+			}
+		}
+		if ( null === $first ) {
+			return '';
+		}
+
+		$value = get_term_meta( $first->term_id, $meta_key, true );
+		if ( is_array( $value ) ) {
+			return '';
+		}
+		return (string) $value;
+	}
+
+	/**
+	 * Binding catalogue for this provider.
+	 *
+	 * @return array<int,array<string,mixed>>
+	 */
+	public function describe(): array {
+		return array(
+			array(
+				'expression' => 'post_term_meta.{taxonomy}.{meta_key}',
+				'label'      => "First term's term meta value (e.g. category ID for an aggregator)",
+				'context'    => 'item',
+				'namespace'  => 'post_term_meta',
+				'dynamic'    => true,
+			),
+		);
+	}
+}

--- a/src/Bindings/Resolver.php
+++ b/src/Bindings/Resolver.php
@@ -44,6 +44,8 @@ final class Resolver {
 			'allow_tags' => array( self::class, 'process_allow_tags' ),
 			'strip_tags' => array( self::class, 'process_strip_tags' ),
 			'map'        => array( self::class, 'process_map' ),
+			'first'      => array( self::class, 'process_first' ),
+			'default'    => array( self::class, 'process_default' ),
 		);
 
 		if ( function_exists( 'apply_filters' ) ) {
@@ -222,6 +224,44 @@ final class Resolver {
 	public static function process_strip_tags( string $value, string $arg ): string {
 		unset( $arg );
 		return wp_strip_all_tags( $value );
+	}
+
+	/**
+	 * Take the first segment of a separator-joined string.
+	 *
+	 * Default separator is `, ` (matching `PostTermProvider`'s default join);
+	 * pass any other character as the argument. The argument cannot contain
+	 * `|` (pipe-syntax conflict — splits the processor chain) or `}` (ends
+	 * the binding). To split on `|`, change the upstream binding to emit a
+	 * different separator first via the modifier (e.g. `{{post_term.category::,}}`).
+	 *
+	 * Examples:
+	 *   {{post_term.category|first}}             -> "Tech" from "Tech, News"
+	 *   {{post_term.category::;|first:;}}        -> "Tech" from "Tech;News"
+	 *
+	 * @param string $value Input value.
+	 * @param string $arg   Separator (default ", ").
+	 */
+	public static function process_first( string $value, string $arg ): string {
+		$separator = '' === $arg ? ', ' : $arg;
+		$pos       = strpos( $value, $separator );
+		return false === $pos ? $value : substr( $value, 0, $pos );
+	}
+
+	/**
+	 * Replace an empty string input with the literal argument.
+	 *
+	 * Differs from `map`'s `*` fallback in that it triggers only on empty
+	 * input — any non-empty value passes through unchanged.
+	 *
+	 * Examples:
+	 *   {{post_term_meta.category._mediba_id|default:99}}  -> "99" if unset
+	 *
+	 * @param string $value Input value.
+	 * @param string $arg   Replacement when $value is empty.
+	 */
+	public static function process_default( string $value, string $arg ): string {
+		return '' === $value ? $arg : $value;
 	}
 
 	/**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -74,6 +74,7 @@ final class Plugin {
 				new Bindings\Providers\PostRawProvider(),
 				new Bindings\Providers\PostMetaProvider(),
 				new Bindings\Providers\PostTermProvider(),
+				new Bindings\Providers\PostTermMetaProvider(),
 				new Bindings\Providers\AuthorProvider(),
 			)
 		);

--- a/tests/Integration/RenderTest.php
+++ b/tests/Integration/RenderTest.php
@@ -515,6 +515,120 @@ final class RenderTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( '<channel/>', $result['xml'] );
 	}
 
+	public function test_post_term_meta_binding_resolves_first_term_meta(): void {
+		// Aggregator category-mapping pattern: assign a CP-side numeric ID to
+		// each WP category once via term meta, then bind to it from the feed.
+		$cat = self::factory()->category->create( array( 'name' => 'Helpful', 'slug' => 'helpful' ) );
+		add_term_meta( $cat, '_mediba_category_id', '91', true );
+
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish', 'post_title' => 'Tip Article' ) );
+		wp_set_post_terms( $post_id, array( $cat ), 'category', false );
+
+		$el      = '<!-- wp:feedwright/element {"tagName":"category","contentMode":"binding","bindingExpression":"{{post_term_meta.category._mediba_category_id|default:99}}"} /-->';
+		$content = '<!-- wp:feedwright/rss --><!-- wp:feedwright/channel -->'
+			. '<!-- wp:feedwright/item-query {"postsPerPage":5} --><!-- wp:feedwright/item -->'
+			. $el
+			. '<!-- /wp:feedwright/item --><!-- /wp:feedwright/item-query -->'
+			. '<!-- /wp:feedwright/channel --><!-- /wp:feedwright/rss -->';
+
+		$feed_post = $this->make_feed_post( $content );
+		$xml       = ( new Renderer( Plugin::build_resolver() ) )->render( $feed_post )['xml'];
+
+		$this->assertStringContainsString( '<category>91</category>', $xml );
+	}
+
+	public function test_post_term_meta_falls_back_via_default_processor_when_meta_unset(): void {
+		// Term exists but no meta value -> default processor supplies fallback.
+		$cat = self::factory()->category->create( array( 'name' => 'Plain', 'slug' => 'plain' ) );
+		// No add_term_meta() call here.
+
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish', 'post_title' => 'Plain Article' ) );
+		wp_set_post_terms( $post_id, array( $cat ), 'category', false );
+
+		$el      = '<!-- wp:feedwright/element {"tagName":"category","contentMode":"binding","bindingExpression":"{{post_term_meta.category._mediba_category_id|default:99}}"} /-->';
+		$content = '<!-- wp:feedwright/rss --><!-- wp:feedwright/channel -->'
+			. '<!-- wp:feedwright/item-query {"postsPerPage":5} --><!-- wp:feedwright/item -->'
+			. $el
+			. '<!-- /wp:feedwright/item --><!-- /wp:feedwright/item-query -->'
+			. '<!-- /wp:feedwright/channel --><!-- /wp:feedwright/rss -->';
+
+		$feed_post = $this->make_feed_post( $content );
+		$xml       = ( new Renderer( Plugin::build_resolver() ) )->render( $feed_post )['xml'];
+
+		$this->assertStringContainsString( '<category>99</category>', $xml );
+	}
+
+	public function test_post_term_meta_uses_first_term_when_multiple_assigned(): void {
+		// Two categories on the same post; the provider returns the first
+		// term's meta. wp_set_post_terms ordering / get_the_terms ordering are
+		// stable for a given config, so we just verify whichever wins maps to
+		// its own term meta value (not the other one's).
+		$cat_a = self::factory()->category->create( array( 'name' => 'A', 'slug' => 'a' ) );
+		$cat_b = self::factory()->category->create( array( 'name' => 'B', 'slug' => 'b' ) );
+		add_term_meta( $cat_a, '_aggregator_id', 'A_ID', true );
+		add_term_meta( $cat_b, '_aggregator_id', 'B_ID', true );
+
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish', 'post_title' => 'Multi Cat' ) );
+		wp_set_post_terms( $post_id, array( $cat_a, $cat_b ), 'category', false );
+
+		$el      = '<!-- wp:feedwright/element {"tagName":"category","contentMode":"binding","bindingExpression":"{{post_term_meta.category._aggregator_id}}"} /-->';
+		$content = '<!-- wp:feedwright/rss --><!-- wp:feedwright/channel -->'
+			. '<!-- wp:feedwright/item-query {"postsPerPage":5} --><!-- wp:feedwright/item -->'
+			. $el
+			. '<!-- /wp:feedwright/item --><!-- /wp:feedwright/item-query -->'
+			. '<!-- /wp:feedwright/channel --><!-- /wp:feedwright/rss -->';
+
+		$feed_post = $this->make_feed_post( $content );
+		$xml       = ( new Renderer( Plugin::build_resolver() ) )->render( $feed_post )['xml'];
+
+		// Output is exactly one of the two term meta values (whichever
+		// get_the_terms() returns first), not a join of both.
+		$this->assertMatchesRegularExpression( '#<category>(A_ID|B_ID)</category>#', $xml );
+		$this->assertStringNotContainsString( 'A_IDB_ID', $xml );
+		$this->assertStringNotContainsString( 'A_ID, B_ID', $xml );
+	}
+
+	public function test_post_term_meta_returns_empty_when_post_has_no_terms(): void {
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish', 'post_title' => 'No Cat' ) );
+		wp_set_post_terms( $post_id, array(), 'category', false );
+
+		$el      = '<!-- wp:feedwright/element {"tagName":"category","contentMode":"binding","bindingExpression":"{{post_term_meta.category._mediba_category_id|default:99}}"} /-->';
+		$content = '<!-- wp:feedwright/rss --><!-- wp:feedwright/channel -->'
+			. '<!-- wp:feedwright/item-query {"postsPerPage":5} --><!-- wp:feedwright/item -->'
+			. $el
+			. '<!-- /wp:feedwright/item --><!-- /wp:feedwright/item-query -->'
+			. '<!-- /wp:feedwright/channel --><!-- /wp:feedwright/rss -->';
+
+		$feed_post = $this->make_feed_post( $content );
+		$xml       = ( new Renderer( Plugin::build_resolver() ) )->render( $feed_post )['xml'];
+
+		$this->assertStringContainsString( '<category>99</category>', $xml );
+	}
+
+	public function test_first_then_map_inline_pattern_for_category_id(): void {
+		// Inline alternative: WP term name -> aggregator ID via |first|map.
+		// Used when there are too few categories to bother with term meta.
+		$tech = self::factory()->category->create( array( 'name' => 'Tech', 'slug' => 'tech' ) );
+		$news = self::factory()->category->create( array( 'name' => 'News', 'slug' => 'news' ) );
+
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish', 'post_title' => 'Inline Map' ) );
+		wp_set_post_terms( $post_id, array( $tech, $news ), 'category', false );
+
+		$el      = '<!-- wp:feedwright/element {"tagName":"category","contentMode":"binding","bindingExpression":"{{post_term.category|first|map:Tech=10,News=20|default:99}}"} /-->';
+		$content = '<!-- wp:feedwright/rss --><!-- wp:feedwright/channel -->'
+			. '<!-- wp:feedwright/item-query {"postsPerPage":5} --><!-- wp:feedwright/item -->'
+			. $el
+			. '<!-- /wp:feedwright/item --><!-- /wp:feedwright/item-query -->'
+			. '<!-- /wp:feedwright/channel --><!-- /wp:feedwright/rss -->';
+
+		$feed_post = $this->make_feed_post( $content );
+		$xml       = ( new Renderer( Plugin::build_resolver() ) )->render( $feed_post )['xml'];
+
+		// Whichever term comes first must map to its own ID; never both joined.
+		$this->assertMatchesRegularExpression( '#<category>(10|20)</category>#', $xml );
+		$this->assertStringNotContainsString( '<category>99</category>', $xml );
+	}
+
 	public function test_no_rss_block_returns_error_xml(): void {
 		$post_id = self::factory()->post->create(
 			array(

--- a/tests/Unit/BindingResolverTest.php
+++ b/tests/Unit/BindingResolverTest.php
@@ -203,4 +203,71 @@ final class BindingResolverTest extends TestCase {
 		// map then truncate (no-op since '1' is already 1 char).
 		$this->assertSame( '1', $r->resolve( '{{foo.k|map:publish=1,*=0|truncate:5}}', $this->ctx() ) );
 	}
+
+	public function test_first_processor_default_separator(): void {
+		$r = new Resolver();
+		$r->add( new FakeProvider( 'foo', array( 'k' => 'Tech, News, Sports' ) ) );
+		$this->assertSame( 'Tech', $r->resolve( '{{foo.k|first}}', $this->ctx() ) );
+	}
+
+	public function test_first_processor_custom_separator(): void {
+		// '|' cannot be used as the separator argument (pipe-syntax conflict);
+		// any other character works. Stick to ';' / ',' / '::' etc.
+		$r = new Resolver();
+		$r->add( new FakeProvider( 'foo', array( 'k' => 'Tech;News;Sports' ) ) );
+		$this->assertSame( 'Tech', $r->resolve( '{{foo.k|first:;}}', $this->ctx() ) );
+	}
+
+	public function test_first_processor_passes_through_when_no_separator(): void {
+		$r = new Resolver();
+		$r->add( new FakeProvider( 'foo', array( 'k' => 'OnlyOne' ) ) );
+		$this->assertSame( 'OnlyOne', $r->resolve( '{{foo.k|first}}', $this->ctx() ) );
+	}
+
+	public function test_first_processor_on_empty_returns_empty(): void {
+		$r = new Resolver();
+		$r->add( new FakeProvider( 'foo', array( 'k' => '' ) ) );
+		$this->assertSame( '', $r->resolve( '{{foo.k|first}}', $this->ctx() ) );
+	}
+
+	public function test_default_processor_replaces_empty(): void {
+		$r = new Resolver();
+		$r->add( new FakeProvider( 'foo', array( 'k' => '' ) ) );
+		$this->assertSame( '99', $r->resolve( '{{foo.k|default:99}}', $this->ctx() ) );
+	}
+
+	public function test_default_processor_passes_through_non_empty(): void {
+		$r = new Resolver();
+		$r->add( new FakeProvider( 'foo', array( 'k' => '42' ) ) );
+		$this->assertSame( '42', $r->resolve( '{{foo.k|default:99}}', $this->ctx() ) );
+	}
+
+	public function test_default_processor_does_not_replace_zero_string(): void {
+		// "0" is non-empty, so default must not replace it.
+		$r = new Resolver();
+		$r->add( new FakeProvider( 'foo', array( 'k' => '0' ) ) );
+		$this->assertSame( '0', $r->resolve( '{{foo.k|default:99}}', $this->ctx() ) );
+	}
+
+	public function test_first_then_map_then_default_chain(): void {
+		// Realistic aggregator pattern: pick the first taxonomy term, look it
+		// up in the inline map, fall back when nothing matches.
+		$r = new Resolver();
+		$r->add( new FakeProvider( 'foo', array( 'k' => 'お役立ち, 芸能' ) ) );
+		$this->assertSame(
+			'91',
+			$r->resolve( '{{foo.k|first|map:お役立ち=91,芸能=92|default:99}}', $this->ctx() )
+		);
+	}
+
+	public function test_chain_falls_through_to_default_when_map_missing(): void {
+		$r = new Resolver();
+		$r->add( new FakeProvider( 'foo', array( 'k' => 'マイナー, 芸能' ) ) );
+		// "マイナー" not in map, no `*` fallback in map => map returns '' =>
+		// default kicks in.
+		$this->assertSame(
+			'99',
+			$r->resolve( '{{foo.k|first|map:お役立ち=91,芸能=92|default:99}}', $this->ctx() )
+		);
+	}
 }


### PR DESCRIPTION
Closes #13.

## Summary
- 新バインディング `post_term_meta.{taxonomy}.{meta_key}` — 投稿に紐づく最初の term の term meta を返す。`<category>` に CP 側 ID を入れる必要があるアグリゲータ向け。
- 新プロセッサ `first` — comma-separated 入力（例：`post_term.{taxonomy}` の戻り値）の最初の要素を取り出す。区切り文字は引数で変更可能（ただし `|` は処理パイプ構文と競合するため不可、ドキュメントに明記）。
- 新プロセッサ `default:value` — 入力が空文字列のときに literal `value` を返す。`map` の `*` と異なり「empty かどうか」だけで判定するので `"0"` 等の falsy 値は素通し。

これで運用上の 2 パターンが Free だけで成立：
- **Inline**: `{{post_term.category|first|map:Tech=10,News=20|default:99}}` — カテゴリ数が少なくマッピングを feed 内で済ませたい場合
- **Term meta**: `{{post_term_meta.category._mediba_category_id|default:99}}` — 編集部が `Posts > Categories` でカテゴリ ID を維持する運用

## Test plan
- [ ] **Render**: term meta が設定された投稿で `<category>91</category>` が出る、未設定で `default` フォールバックが効く
- [ ] **Render (inline)**: `|first|map|default` チェーンが期待通り動作する
- [ ] **Multi-term**: 投稿に複数 category が付いていても、最初の term の meta だけが返る（join されない）
- [ ] **Tests**: `composer test:unit` (66 passed), wp-env tests (112 passed), `composer phpcs` (29 passed)
- [ ] **Docs**: `docs/requirements.md` §14.4 / §14.6.1 / 5 章ディレクトリ図 / 14.6 wiring 例 を更新済み
- [ ] **i18n**: PHP のみ変更で新規ユーザ向け文字列なし、翻訳ファイル更新不要

## 設計上のメモ
- `post_term_meta` は `get_the_terms()` の戻り順での最初の 1 件のみを参照する。複数 term の同一 meta を集約したいケースは別 issue で扱う想定（現状はスコープ外）。
- `first` の引数 `|` 不可制約は、processor pipe syntax と衝突するため。ドキュメントで「上流バインディングの modifier 側で別の区切り文字を発行してから `first` に渡す」回避策を案内している。
- `default` は意図的に `map` の `*` と機能を分けている（`map` は「キー不一致時」、`default` は「empty 時」）。両方を組み合わせて使えるようテスト済み。