### PR TITLE
chore: bump version to 0.1.3 (#17)

### DIFF
--- a/feedwright.php
+++ b/feedwright.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Feedwright
  * Plugin URI:        https://github.com/mt8/feedwright
  * Description:       Edit custom RSS / Atom / XML feeds visually in the WordPress block editor.
- * Version:           0.1.2
+ * Version:           0.1.3
  * Requires at least: 6.5
  * Requires PHP:      8.3
  * Author:            mt8
@@ -18,7 +18,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'FEEDWRIGHT_VERSION', '0.1.2' );
+define( 'FEEDWRIGHT_VERSION', '0.1.3' );
 define( 'FEEDWRIGHT_PLUGIN_FILE', __FILE__ );
 define( 'FEEDWRIGHT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'FEEDWRIGHT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "feedwright",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "Edit custom RSS / Atom / XML feeds visually in the WordPress block editor.",
     "author": "mt8",
     "license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: rss, feed, atom, mrss, xml
 Requires at least: 6.5
 Tested up to: 6.9
 Requires PHP: 8.3
-Stable tag: 0.1.2
+Stable tag: 0.1.3
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -35,6 +35,11 @@ The default URL pattern is `/feedwright/{slug}/`. You can change the prefix in F
 Yes. Declare the namespace prefix and URI on the `<rss>` block, then use prefixed tag names (e.g. `media:thumbnail`) on element blocks and attributes.
 
 == Changelog ==
+
+= 0.1.3 =
+* Feature: new `feedwright/sub-query` and `feedwright/sub-item` blocks expand related posts inside each item template (taxonomy term match or manual ID list). Useful for `<smp:relation>`, `<mdf:relatedLink>`, `<g:additional_image_link>`-style aggregator requirements.
+* Feature: new `post_term_meta.{taxonomy}.{meta_key}` binding plus `first` / `default` processors for editorial-managed category-ID mapping (e.g. mediba `<category>` numeric IDs).
+* Feature: new `outputMode` attribute on the `<rss>` block (default `strict`). Strict produces minified XML and entity-encodes `'` / `"` in regular text nodes; CDATA-binding elements keep their CDATA wrapper. The new `?pretty=1` query parameter forces formatted XML for admins / `WP_DEBUG` builds.
 
 = 0.1.2 =
 * Fix: item-template can now be placed inside each item-query individually instead of being a global singleton. Multiple item-query blocks each get their own item-template.

--- a/tests/Unit/PluginHeaderTest.php
+++ b/tests/Unit/PluginHeaderTest.php
@@ -36,7 +36,7 @@ final class PluginHeaderTest extends TestCase {
 	public function test_plugin_header_metadata(): void {
 		$header = $this->read_header();
 		$this->assertSame( 'Feedwright', $header['Plugin Name'] ?? '' );
-		$this->assertSame( '0.1.2', $header['Version'] ?? '' );
+		$this->assertSame( '0.1.3', $header['Version'] ?? '' );
 		$this->assertSame( '8.3', $header['Requires PHP'] ?? '' );
 		$this->assertSame( '6.5', $header['Requires at least'] ?? '' );
 		$this->assertSame( 'feedwright', $header['Text Domain'] ?? '' );


### PR DESCRIPTION
Closes #17.

## 含まれる変更
- #11 sub-query / sub-item ブロック (PR #12)
- #13 `first` / `default` プロセッサ + `post_term_meta` バインディング (PR #14)
- #15 `outputMode` 属性 (strict / compat) と `?pretty=1` クエリパラメータ (PR #16)

## バージョン更新ファイル
- `feedwright.php`: `Version` ヘッダ + `FEEDWRIGHT_VERSION` 定数
- `package.json`: `version`
- `readme.txt`: `Stable tag` + Changelog エントリ
- `tests/Unit/PluginHeaderTest.php`: バージョン assertion

## Test plan
- [ ] `composer test:unit` (72 passed)
- [ ] CI: phpcs / phpunit マトリクス / Plugin Check / E2E グリーン
- [ ] readme.txt の Changelog が `= 0.1.3 =` セクションを正しく含む