### PR TITLE
show `<![CDATA[...]]>` wrapper in the editor for cdata-binding mode (#20)

### DIFF
--- a/blocks/_shared/editor.css
+++ b/blocks/_shared/editor.css
@@ -132,6 +132,24 @@
 	font-size: 13px;
 }
 
+/* cdata-binding mode: visually wrap the expression with <![CDATA[ ... ]]>
+   so the editor mirrors what the renderer will emit. */
+.feedwright-block-element__binding--cdata {
+	background: #eef2ff;
+	border-color: #c7d2fe;
+}
+
+.feedwright-block-element__cdata-marker {
+	color: #4338ca;
+	opacity: 0.75;
+	font-size: 12px;
+	user-select: none;
+}
+
+.feedwright-block-element__cdata-body {
+	margin: 0 6px;
+}
+
 .feedwright-block-element__value {
 	color: #166534;
 }

--- a/blocks/element/edit.js
+++ b/blocks/element/edit.js
@@ -75,10 +75,24 @@ export default function Edit( { attributes, setAttributes, context } ) {
 			);
 			break;
 		case 'binding':
-		case 'cdata-binding':
 			preview = (
 				<code className="feedwright-block-element__binding">
 					{ bindingExpression || __( '{{...}}', 'feedwright' ) }
+				</code>
+			);
+			break;
+		case 'cdata-binding':
+			preview = (
+				<code className="feedwright-block-element__binding feedwright-block-element__binding--cdata">
+					<span className="feedwright-block-element__cdata-marker">
+						&lt;![CDATA[
+					</span>
+					<span className="feedwright-block-element__cdata-body">
+						{ bindingExpression || __( '{{...}}', 'feedwright' ) }
+					</span>
+					<span className="feedwright-block-element__cdata-marker">
+						]]&gt;
+					</span>
 				</code>
 			);
 			break;


### PR DESCRIPTION
Closes #20.

## Summary
`feedwright/element` ブロックの contentMode を **「binding (CDATA)」** に切り替えると、エディタのブロック本文プレビューで バインディング式が `<![CDATA[ ... ]]>` でラップされて表示されるようになる。出力 XML と編集 UI の見た目が一致するため、Author が「これは CDATA で出る」ことを視覚的に確認できる。

## 変更点
- `blocks/element/edit.js`：`switch ( contentMode )` の `binding` と `cdata-binding` ケースを分割。後者は `<![CDATA[` / `]]>` マーカー span でバインディング式を挟む
- `blocks/_shared/editor.css`：cdata 用バリアント `feedwright-block-element__binding--cdata` と marker / body のスタイル追加（淡いインディゴ系で背景・マーカーを区別）
- 出力 XML には一切影響なし。`binding` / `static` / `children` / `empty` モードは変更なし
- 翻訳対象文字列の追加なし（マーカーは XML リテラル）

## Test plan
- [ ] **Visual**：element ブロックの Inspector で「binding (CDATA)」に切り替えると、ブロック本文に `<![CDATA[ {{post.post_content}} ]]>` の形で表示される
- [ ] **Visual**：「binding」に戻すとマーカーが消え、従来表示に戻る
- [ ] **Visual**：static / children / empty モードでは何も変化しない
- [ ] **配信 XML**：`?feedwright_feed_slug=...` で取得する XML は変更前と同一（差分なし）
- [ ] **Tests**：`composer test:unit` (72 passed)、`composer phpcs` (29 passed)