### PR TITLE
auto-append `?pretty=1` to feedwright_feed permalinks in admin context (#25)

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1666,7 +1666,7 @@ Edits the `attributes` array on the `element` block.
 
 `feedwright_feed` registers with `public=true` / `publicly_queryable=true`, so the standard Gutenberg preview / publish flow handles XML previewing without a custom sidebar:
 
-- The editor's "View" / "Preview" buttons resolve via `PostType::filter_permalink`, which redirects to `/{base}/{slug}/`.
+- The editor's "View" / "Preview" buttons resolve via `PostType::filter_permalink`, which redirects to `/{base}/{slug}/`. In admin contexts (`is_admin()` true) for users that can `manage_options`, the filter additionally appends `?pretty=1` so the formatted variant opens by default — front-end and REST contexts get the canonical clean URL.
 - Published posts are served by `Routing\FeedEndpoint::maybe_serve_feed` as production XML (with `?pretty=1` available to admins / `WP_DEBUG` for human inspection).
 - Drafts / non-published posts return 404 from the public URL — preview UX for unpublished feeds is intentionally left to the standard WordPress preview path that consumers can opt into via filters.
 

--- a/src/PostType.php
+++ b/src/PostType.php
@@ -65,6 +65,13 @@ final class PostType {
 	 * which is the wrong endpoint and is what breaks the editor's "View" link
 	 * and the slug input on permalink structures other than `/%postname%/`.
 	 *
+	 * In admin contexts (editor / list table / admin bar) for users that can
+	 * `manage_options`, append `?pretty=1` so clicking "Feed を表示" opens the
+	 * formatted variant. Front-end and REST contexts are unaffected — the
+	 * canonical sharing URL stays clean. Even if a `?pretty=1` URL leaks to a
+	 * non-admin, `Routing\FeedEndpoint::is_pretty_request()` rejects them and
+	 * the response is the standard minified XML.
+	 *
 	 * @param string   $permalink Default permalink computed by core.
 	 * @param \WP_Post $post      Post being linked.
 	 */
@@ -76,7 +83,13 @@ final class PostType {
 			return $permalink;
 		}
 		$feed_url = \Feedwright\Routing\FeedEndpoint::feed_url( $post->post_name );
-		return '' !== $feed_url ? $feed_url : $permalink;
+		if ( '' === $feed_url ) {
+			return $permalink;
+		}
+		if ( is_admin() && current_user_can( 'manage_options' ) ) {
+			$feed_url = add_query_arg( 'pretty', '1', $feed_url );
+		}
+		return $feed_url;
 	}
 
 	/**

--- a/tests/Integration/PostTypeTest.php
+++ b/tests/Integration/PostTypeTest.php
@@ -63,6 +63,83 @@ final class PostTypeTest extends WP_UnitTestCase {
 		$this->assertSame( PostType::SLUG, get_post_type( $post_id ) );
 	}
 
+	private function make_feed_post(): int {
+		return self::factory()->post->create(
+			array(
+				'post_type'   => PostType::SLUG,
+				'post_title'  => 'Permalink test feed',
+				'post_name'   => 'permalink-test',
+				'post_status' => 'publish',
+			)
+		);
+	}
+
+	public function test_filter_permalink_appends_pretty_for_admin_in_admin_context(): void {
+		$admin = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin );
+		$post_id = $this->make_feed_post();
+
+		set_current_screen( 'edit.php' );
+		try {
+			$url = get_permalink( $post_id );
+			$this->assertStringContainsString( '/feedwright/permalink-test/', $url );
+			$this->assertStringContainsString( 'pretty=1', $url );
+		} finally {
+			set_current_screen( 'front' );
+		}
+	}
+
+	public function test_filter_permalink_omits_pretty_in_frontend_context(): void {
+		// Admin user but front-end context: pretty must NOT be appended (this
+		// is the URL that gets shared / embedded by the theme).
+		$admin = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin );
+		$post_id = $this->make_feed_post();
+
+		set_current_screen( 'front' );
+		$url = get_permalink( $post_id );
+		$this->assertStringContainsString( '/feedwright/permalink-test/', $url );
+		$this->assertStringNotContainsString( 'pretty=1', $url );
+	}
+
+	public function test_filter_permalink_omits_pretty_for_non_admin_users(): void {
+		// Editor in admin context (e.g. comments screen) — still no pretty,
+		// since they do not have manage_options.
+		$editor = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor );
+		$post_id = $this->make_feed_post();
+
+		set_current_screen( 'edit.php' );
+		try {
+			$url = get_permalink( $post_id );
+			$this->assertStringContainsString( '/feedwright/permalink-test/', $url );
+			$this->assertStringNotContainsString( 'pretty=1', $url );
+		} finally {
+			set_current_screen( 'front' );
+		}
+	}
+
+	public function test_filter_permalink_does_not_touch_other_post_types(): void {
+		$admin = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin );
+		$other = self::factory()->post->create(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_title'  => 'Regular post',
+				'post_name'   => 'regular',
+			)
+		);
+
+		set_current_screen( 'edit.php' );
+		try {
+			$url = get_permalink( $other );
+			$this->assertStringNotContainsString( 'pretty=1', $url, 'pretty must not leak onto unrelated post types' );
+		} finally {
+			set_current_screen( 'front' );
+		}
+	}
+
 	public function test_default_template_has_minimum_skeleton(): void {
 		$post_type  = new PostType();
 		$template   = $post_type->default_template();


### PR DESCRIPTION
Closes #25.

## Summary
管理画面コンテキスト (`is_admin()` 真) で **管理者** (`current_user_can('manage_options')`) がパーマリンクを取得する経路では、`PostType::filter_permalink` が返す URL に `?pretty=1` を自動付与する。これにより編集画面・投稿一覧・admin bar の「フィードを表示」リンクから整形済み XML が直接開くようになる。

フロントエンドや REST API レスポンスのパーマリンクには影響なし — 共有用の canonical URL は引き続き `?pretty=1` 無しのクリーンな形のまま。仮に管理画面の URL バーから admin が `?pretty=1` 入りの URL をコピーしてしまっても、`FeedEndpoint::is_pretty_request()` で gating されるので非管理者には minified XML が返り実害なし。

## Changes
- `src/PostType.php`：`filter_permalink()` に admin-context 条件分岐を追加
- `tests/Integration/PostTypeTest.php`：admin context で付く / front-end で付かない / 非管理者で付かない / 他の post_type に影響しない の 4 ケース追加
- `docs/requirements.md` §17.3：プレビュー / 公開フローの説明に admin pretty 付与を追記

## Test plan
- [ ] **Visual**：管理画面の編集画面・投稿一覧・admin bar の「フィードを表示」リンク URL に `?pretty=1` が付いている
- [ ] **Visual**：クリックすると整形済み XML が表示される
- [ ] **Visual**：ログアウト状態 / フロントエンド経由のパーマリンクには `?pretty=1` が付かない
- [ ] **Tests**：`composer test:unit` (72 passed)、wp-env tests (123 passed)、`composer phpcs` (29 passed)

## トレードオフ（再確認）
- 管理画面の URL バーに表示される Permalink にも `?pretty=1` が混じる。共有用クリーン URL が欲しい場合は手で削除する必要あり
- 当面この挙動で OK としているが、UI で「クリーンな共有 URL」を別表示する case が出てきたら別 issue で扱う