### PR TITLE
chore: bump version to 0.1.4 (#33)

### DIFF
--- a/feedwright.php
+++ b/feedwright.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Feedwright
  * Plugin URI:        https://github.com/mt8/feedwright
  * Description:       Edit custom RSS / Atom / XML feeds visually in the WordPress block editor.
- * Version:           0.1.3
+ * Version:           0.1.4
  * Requires at least: 6.5
  * Requires PHP:      8.3
  * Author:            mt8
@@ -18,7 +18,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'FEEDWRIGHT_VERSION', '0.1.3' );
+define( 'FEEDWRIGHT_VERSION', '0.1.4' );
 define( 'FEEDWRIGHT_PLUGIN_FILE', __FILE__ );
 define( 'FEEDWRIGHT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'FEEDWRIGHT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "feedwright",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "description": "Edit custom RSS / Atom / XML feeds visually in the WordPress block editor.",
     "author": "mt8",
     "license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: rss, feed, atom, mrss, xml
 Requires at least: 6.5
 Tested up to: 6.9
 Requires PHP: 8.3
-Stable tag: 0.1.3
+Stable tag: 0.1.4
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -35,6 +35,16 @@ The default URL pattern is `/feedwright/{slug}/`. You can change the prefix in F
 Yes. Declare the namespace prefix and URI on the `<rss>` block, then use prefixed tag names (e.g. `media:thumbnail`) on element blocks and attributes.
 
 == Changelog ==
+
+= 0.1.4 =
+* Feature: new `feedwright/when` block wraps inner blocks with a binding-driven gate. Compose with the `eq` / `in` / `map` / `default` / `first` processors to render elements only under specific conditions (e.g. emit `<mdf:deleted/>` only when the post is in the trash).
+* Feature: `item-query` now accepts the `trash` post status, plus a `trashWithinDays` cap that keeps trashed posts in the feed only for a configurable window. Live (non-trashed) posts are unaffected.
+* Feature: new `eq` / `in` binding processors for direct equality and list-membership checks (`{{post_raw.post_status|eq:trash}}`, `{{post_raw.post_status|in:trash,draft}}`). Both compose naturally with `feedwright/when`.
+* Feature: `first` and `default` processors are now surfaced in the editor's binding autocomplete.
+* Feature: in admin contexts (editor, post list, admin bar) the `feedwright_feed` permalink auto-appends `?pretty=1` so the "View" link opens formatted XML by default. Front-end and REST contexts keep the canonical clean URL.
+* Feature: the element block's editor preview now wraps `cdata-binding` expressions with `<![CDATA[ ... ]]>` markers so the CDATA intent is visible at a glance.
+* Improvement: `feedwright/when` truthiness check is whitespace-tolerant — a stray trailing space in the expression no longer flips the gate to always-true.
+* Cleanup: removed the dedicated "Feedwright XML Preview" sidebar panel and its REST endpoint; the standard Gutenberg preview / publish flow handles XML preview natively.
 
 = 0.1.3 =
 * Feature: new `feedwright/sub-query` and `feedwright/sub-item` blocks expand related posts inside each item template (taxonomy term match or manual ID list). Useful for `<smp:relation>`, `<mdf:relatedLink>`, `<g:additional_image_link>`-style aggregator requirements.

--- a/tests/Unit/PluginHeaderTest.php
+++ b/tests/Unit/PluginHeaderTest.php
@@ -36,7 +36,7 @@ final class PluginHeaderTest extends TestCase {
 	public function test_plugin_header_metadata(): void {
 		$header = $this->read_header();
 		$this->assertSame( 'Feedwright', $header['Plugin Name'] ?? '' );
-		$this->assertSame( '0.1.3', $header['Version'] ?? '' );
+		$this->assertSame( '0.1.4', $header['Version'] ?? '' );
 		$this->assertSame( '8.3', $header['Requires PHP'] ?? '' );
 		$this->assertSame( '6.5', $header['Requires at least'] ?? '' );
 		$this->assertSame( 'feedwright', $header['Text Domain'] ?? '' );


### PR DESCRIPTION
Closes #33.

## 含まれる変更
- #19 編集画面の「Feedwright XML プレビュー」サイドバー削除 (PR #21)
- #20 cdata-binding モードに `<![CDATA[...]]>` の視覚マーカー (PR #22)
- #23 `first` / `default` プロセッサを autocomplete に追加 (PR #24)
- #25 admin context のパーマリンクに `?pretty=1` 自動付与 (PR #26)
- #28 `item-query` で `trash` ステータス + `trashWithinDays` 窓 (PR #29)
- #27 `feedwright/when` 条件出力ブロック (PR #30)
- #31 `eq` / `in` プロセッサ + `feedwright/when` whitespace tolerance (PR #32)

## バージョン更新ファイル
- `feedwright.php`: `Version` ヘッダ + `FEEDWRIGHT_VERSION` 定数
- `package.json`: `version`
- `readme.txt`: `Stable tag` + Changelog
- `tests/Unit/PluginHeaderTest.php`: バージョン assertion

## Test plan
- [ ] `composer test:unit` (80 passed)
- [ ] CI: phpcs / phpunit マトリクス / Plugin Check / E2E グリーン
- [ ] readme.txt の Changelog に `= 0.1.4 =` セクションが含まれる