### PR TITLE
fix: add mkdir step before writing into /wordpress/seeds (#37)

### DIFF
--- a/playground/blueprint.json
+++ b/playground/blueprint.json
@@ -24,6 +24,8 @@
       }
     },
 
+    { "step": "mkdir", "path": "/wordpress/seeds" },
+
     {
       "step": "writeFile",
       "path": "/wordpress/seeds/posts.xml",


### PR DESCRIPTION
Closes #37.

## Summary
Playground 起動時に blueprint ステップ #4 で

> Could not write to \"/wordpress/seeds/posts.xml\": There is no such file or directory OR the parent directory does not exist.

が出る問題の修正。`writeFile` は親ディレクトリを自動作成しないため、`mkdir` ステップを 1 つ追加する。

## Change
- `playground/blueprint.json`: `setSiteOptions` の直後に `{ "step": "mkdir", "path": "/wordpress/seeds" }` を挿入

## Test plan
- [ ] Playground を起動：https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/mt8/feedwright/main/playground/blueprint.json
- [ ] エラーなく完走、ランディングがフィード一覧画面、3 フィード（goonews / mediba / smartnews）が公開状態
- [ ] 30 投稿の post 一覧にアイキャッチが付いている