### PR TITLE
fix: flatten Playground seed paths to /wordpress/ root (#39)

### DIFF
--- a/playground/blueprint.json
+++ b/playground/blueprint.json
@@ -24,11 +24,9 @@
       }
     },
 
-    { "step": "mkdir", "path": "/wordpress/seeds" },
-
     {
       "step": "writeFile",
-      "path": "/wordpress/seeds/posts.xml",
+      "path": "/wordpress/posts.xml",
       "data": {
         "resource": "url",
         "url": "https://raw.githubusercontent.com/mt8/feedwright/main/playground/seeds/posts.xml"
@@ -36,7 +34,7 @@
     },
     {
       "step": "writeFile",
-      "path": "/wordpress/seeds/seed-helpers.php",
+      "path": "/wordpress/seed-helpers.php",
       "data": {
         "resource": "url",
         "url": "https://raw.githubusercontent.com/mt8/feedwright/main/playground/seeds/seed-helpers.php"
@@ -44,42 +42,42 @@
     },
     {
       "step": "writeFile",
-      "path": "/wordpress/seeds/seed-shared.php",
+      "path": "/wordpress/seed-shared.php",
       "data": {
         "resource": "url",
         "url": "https://raw.githubusercontent.com/mt8/feedwright/main/playground/seeds/seed-shared.php"
       }
     },
-    { "step": "wp-cli", "command": "wp eval-file seeds/seed-shared.php" },
+    { "step": "wp-cli", "command": "wp eval-file seed-shared.php" },
 
     {
       "step": "writeFile",
-      "path": "/wordpress/seeds/seed-goonews.php",
+      "path": "/wordpress/seed-goonews.php",
       "data": {
         "resource": "url",
         "url": "https://raw.githubusercontent.com/mt8/feedwright/main/playground/seeds/seed-goonews.php"
       }
     },
-    { "step": "wp-cli", "command": "wp eval-file seeds/seed-goonews.php" },
+    { "step": "wp-cli", "command": "wp eval-file seed-goonews.php" },
 
     {
       "step": "writeFile",
-      "path": "/wordpress/seeds/seed-mediba.php",
+      "path": "/wordpress/seed-mediba.php",
       "data": {
         "resource": "url",
         "url": "https://raw.githubusercontent.com/mt8/feedwright/main/playground/seeds/seed-mediba.php"
       }
     },
-    { "step": "wp-cli", "command": "wp eval-file seeds/seed-mediba.php" },
+    { "step": "wp-cli", "command": "wp eval-file seed-mediba.php" },
 
     {
       "step": "writeFile",
-      "path": "/wordpress/seeds/seed-smartnews.php",
+      "path": "/wordpress/seed-smartnews.php",
       "data": {
         "resource": "url",
         "url": "https://raw.githubusercontent.com/mt8/feedwright/main/playground/seeds/seed-smartnews.php"
       }
     },
-    { "step": "wp-cli", "command": "wp eval-file seeds/seed-smartnews.php" }
+    { "step": "wp-cli", "command": "wp eval-file seed-smartnews.php" }
   ]
 }


### PR DESCRIPTION
## Summary

- `mkdir` step in #38 didn't actually create `/wordpress/seeds/` against the `writeFile` virtual filesystem, so the blueprint kept failing with "parent directory does not exist"
- Drop the subdir entirely and put all seed files directly under `/wordpress/`
- Adjust `wp eval-file` commands accordingly

## Why this works

`/wordpress/` is guaranteed to exist in Playground (it's the WP install root), so `writeFile` succeeds without any prior `mkdir`. Seed PHP files reference each other via `__DIR__`, so flattening doesn't break the cross-includes.

Closes #39.

## Test plan

- [ ] Open Playground with this blueprint and confirm all 4 wp-cli steps succeed
- [ ] `feedwright_feed` posts (goonews / mediba / smartnews) appear in the admin list
- [ ] Sample posts from `posts.xml` are imported with featured images