### PR TITLE
chore: bump version to 0.2.0 (#41)

### DIFF
--- a/feedwright.php
+++ b/feedwright.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Feedwright
  * Plugin URI:        https://github.com/mt8/feedwright
  * Description:       Edit custom RSS / Atom / XML feeds visually in the WordPress block editor.
- * Version:           0.1.4
+ * Version:           0.2.0
  * Requires at least: 6.5
  * Requires PHP:      8.3
  * Author:            mt8
@@ -18,7 +18,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'FEEDWRIGHT_VERSION', '0.1.4' );
+define( 'FEEDWRIGHT_VERSION', '0.2.0' );
 define( 'FEEDWRIGHT_PLUGIN_FILE', __FILE__ );
 define( 'FEEDWRIGHT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'FEEDWRIGHT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "feedwright",
-    "version": "0.1.4",
+    "version": "0.2.0",
     "description": "Edit custom RSS / Atom / XML feeds visually in the WordPress block editor.",
     "author": "mt8",
     "license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: rss, feed, atom, mrss, xml
 Requires at least: 6.5
 Tested up to: 6.9
 Requires PHP: 8.3
-Stable tag: 0.1.4
+Stable tag: 0.2.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -35,6 +35,10 @@ The default URL pattern is `/feedwright/{slug}/`. You can change the prefix in F
 Yes. Declare the namespace prefix and URI on the `<rss>` block, then use prefixed tag names (e.g. `media:thumbnail`) on element blocks and attributes.
 
 == Changelog ==
+
+= 0.2.0 =
+* Playground demo: per-aggregator seed scripts (`seed-goonews.php`, `seed-mediba.php`, `seed-smartnews.php`) plus a 30-post fixture from `posts.xml` and sideloaded Unsplash featured images. Seeds also publish Feedwright wordmark logos for the SmartNews `snf:logo` / `snf:darkModeLogo` channel elements.
+* Playground blueprint: flatten seed paths to `/wordpress/` root so `writeFile` no longer fails on a missing parent directory in the virtual filesystem.
 
 = 0.1.4 =
 * Feature: new `feedwright/when` block wraps inner blocks with a binding-driven gate. Compose with the `eq` / `in` / `map` / `default` / `first` processors to render elements only under specific conditions (e.g. emit `<mdf:deleted/>` only when the post is in the trash).

--- a/tests/Unit/PluginHeaderTest.php
+++ b/tests/Unit/PluginHeaderTest.php
@@ -36,7 +36,7 @@ final class PluginHeaderTest extends TestCase {
 	public function test_plugin_header_metadata(): void {
 		$header = $this->read_header();
 		$this->assertSame( 'Feedwright', $header['Plugin Name'] ?? '' );
-		$this->assertSame( '0.1.4', $header['Version'] ?? '' );
+		$this->assertSame( '0.2.0', $header['Version'] ?? '' );
 		$this->assertSame( '8.3', $header['Requires PHP'] ?? '' );
 		$this->assertSame( '6.5', $header['Requires at least'] ?? '' );
 		$this->assertSame( 'feedwright', $header['Text Domain'] ?? '' );


### PR DESCRIPTION
## Summary

- Bump `Version:` header / `FEEDWRIGHT_VERSION` / `package.json` / `Stable tag` to **0.2.0**
- Update `tests/Unit/PluginHeaderTest.php` expected version
- Add `= 0.2.0 =` changelog entry

## Changelog (since 0.1.4)

Playground demo only — no plugin runtime changes:

- Per-aggregator seed scripts (`seed-goonews.php` / `seed-mediba.php` / `seed-smartnews.php`), 30-post `posts.xml` fixture with sideloaded Unsplash featured images, Feedwright wordmark for SmartNews `snf:logo` / `snf:darkModeLogo`. (#35)
- Flatten Playground seed paths to `/wordpress/` root so `writeFile` succeeds without a prior `mkdir`. (#37, #39)

Closes #41.

## Test plan

- [ ] `composer run test:unit` — `PluginHeaderTest` passes with new version
- [ ] After merge: `git tag 0.2.0 && git push origin 0.2.0` to trigger release