### PR TITLE
feat: show TAG NAME as the element block label in List View (#43)

### DIFF
--- a/blocks/element/index.js
+++ b/blocks/element/index.js
@@ -7,6 +7,12 @@ import variations from './variations';
 registerBlockType( metadata.name, {
 	edit: Edit,
 	save: () => <InnerBlocks.Content />,
+	__experimentalLabel: ( attributes, { context } ) => {
+		if ( context === 'list-view' && attributes?.tagName ) {
+			return `<${ attributes.tagName }>`;
+		}
+		return undefined;
+	},
 } );
 
 variations.forEach( ( variation ) => {

--- a/blocks/element/index.js
+++ b/blocks/element/index.js
@@ -8,10 +8,14 @@ registerBlockType( metadata.name, {
 	edit: Edit,
 	save: () => <InnerBlocks.Content />,
 	__experimentalLabel: ( attributes, { context } ) => {
-		if ( context === 'list-view' && attributes?.tagName ) {
-			return `<${ attributes.tagName }>`;
+		if ( context !== 'list-view' ) {
+			return undefined;
 		}
-		return undefined;
+		const tag =
+			typeof attributes?.tagName === 'string'
+				? attributes.tagName.trim()
+				: '';
+		return tag || undefined;
 	},
 } );
 


### PR DESCRIPTION
## Summary

- Add `__experimentalLabel` to `feedwright/element` registration
- When `context === 'list-view'` and `tagName` is set, return `<{tagName}>`
- Falls back to the default block title (`Element`) when `tagName` is empty, or in any non-list-view context (Inserter, breadcrumbs, status bar)

Closes #43.

## Visual check

Before: every Element row in the List View read **`Element`**, indistinguishable from siblings.

After: rows read **`<title>`**, **`<link>`**, **`<media:thumbnail>`**, etc. — matching the configured TAG NAME attribute.

## Test plan

- [ ] Open a feedwright_feed in the editor; List View shows each element by its tag name
- [ ] Add a new Element block with no TAG NAME — it shows as "Element" until a name is entered
- [ ] Inserter still shows the "Element" card with its full description (label override does not bleed into other contexts)
- [ ] Namespaced names like `media:thumbnail` render as `<media:thumbnail>`