### PR TITLE
chore: bump version to 0.2.1 (#45)

### DIFF
--- a/feedwright.php
+++ b/feedwright.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Feedwright
  * Plugin URI:        https://github.com/mt8/feedwright
  * Description:       Edit custom RSS / Atom / XML feeds visually in the WordPress block editor.
- * Version:           0.2.0
+ * Version:           0.2.1
  * Requires at least: 6.5
  * Requires PHP:      8.3
  * Author:            mt8
@@ -18,7 +18,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'FEEDWRIGHT_VERSION', '0.2.0' );
+define( 'FEEDWRIGHT_VERSION', '0.2.1' );
 define( 'FEEDWRIGHT_PLUGIN_FILE', __FILE__ );
 define( 'FEEDWRIGHT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'FEEDWRIGHT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "feedwright",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "Edit custom RSS / Atom / XML feeds visually in the WordPress block editor.",
     "author": "mt8",
     "license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: rss, feed, atom, mrss, xml
 Requires at least: 6.5
 Tested up to: 6.9
 Requires PHP: 8.3
-Stable tag: 0.2.0
+Stable tag: 0.2.1
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -35,6 +35,9 @@ The default URL pattern is `/feedwright/{slug}/`. You can change the prefix in F
 Yes. Declare the namespace prefix and URI on the `<rss>` block, then use prefixed tag names (e.g. `media:thumbnail`) on element blocks and attributes.
 
 == Changelog ==
+
+= 0.2.1 =
+* Improvement: the editor's List View now labels each `feedwright/element` row with its configured `tagName` (e.g. `title`, `media:thumbnail`) instead of a uniform "Element", making it easy to navigate large feeds at a glance. Empty tag names still fall back to the default block title.
 
 = 0.2.0 =
 * Playground demo: per-aggregator seed scripts (`seed-goonews.php`, `seed-mediba.php`, `seed-smartnews.php`) plus a 30-post fixture from `posts.xml` and sideloaded Unsplash featured images. Seeds also publish Feedwright wordmark logos for the SmartNews `snf:logo` / `snf:darkModeLogo` channel elements.

--- a/tests/Unit/PluginHeaderTest.php
+++ b/tests/Unit/PluginHeaderTest.php
@@ -36,7 +36,7 @@ final class PluginHeaderTest extends TestCase {
 	public function test_plugin_header_metadata(): void {
 		$header = $this->read_header();
 		$this->assertSame( 'Feedwright', $header['Plugin Name'] ?? '' );
-		$this->assertSame( '0.2.0', $header['Version'] ?? '' );
+		$this->assertSame( '0.2.1', $header['Version'] ?? '' );
 		$this->assertSame( '8.3', $header['Requires PHP'] ?? '' );
 		$this->assertSame( '6.5', $header['Requires at least'] ?? '' );
 		$this->assertSame( 'feedwright', $header['Text Domain'] ?? '' );


### PR DESCRIPTION
## Summary

Patch release after 0.2.0:

- Bump `Version:` header / `FEEDWRIGHT_VERSION` / `package.json` / `Stable tag` to **0.2.1**
- Update `tests/Unit/PluginHeaderTest.php` expected version
- Add `= 0.2.1 =` changelog entry

## Changelog (since 0.2.0)

- Editor: List View now labels each `feedwright/element` row with its configured `tagName` (e.g. `title`, `media:thumbnail`) instead of a uniform "Element". (#43, #44)

Closes #45.

## Test plan

- [ ] `composer run test:unit` passes
- [ ] After merge: `git tag 0.2.1 && git push origin 0.2.1`